### PR TITLE
Remove Mockery

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "r4b8iiiiiit-Azure-Pipeline-Html-Report-Updated",
     "publisher": "r4b8iiiiiitOS",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "author": "Jakub Rumpca,AwardedSolutions,r4b8iiiiiit",
     "name": "Html Viewer",
     "description": "Embed HTML report in Azure Pipelines - patches Jakub Rumpca,AwardedSolutions - Updated",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,7 +5,7 @@
     "description": "Embed HTML report in Azure Pipelines - patches Jakub Rumpca,AwardedSolutions - Updated",
     "publisher": "r4b8iiiiiitOS",
     "author": "Jakub Rumpca,AwardedSolutions,r4b8iiiiiit",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "public": false,
     "categories": ["Azure Pipelines"],
     "icons": {


### PR DESCRIPTION
Mockery removal to fix dependabot issue (CVE-2022-37614)

Mockery no longer needed and has an unpatchable vulnerability https://github.com/microsoft/azure-pipelines-task-lib/pull/968