### PR TITLE
Remove Mockery

### DIFF
--- a/PublishHtmlReport/package-lock.json
+++ b/PublishHtmlReport/package-lock.json
@@ -549,7 +549,6 @@
       "license": "MIT",
       "dependencies": {
         "minimatch": "10.0.1",
-        "mockery": "^2.1.0",
         "q": "^1.1.2",
         "semver": "^5.1.0",
         "shelljs": "^0.9.2",
@@ -2355,11 +2354,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-gUQA33ayi0tuAhr/rJNZPr7Q7uvlBt4gyJPbi0CDcAfIzIrDu1YgGMFgmAu3stJqBpK57m7+RxUbcS+pt59fKQ=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",


### PR DESCRIPTION
Mockery removal to fix dependabot issue (https://github.com/advisories/GHSA-gmwp-3pwc-3j3g)

Mockery no longer needed and has an unpatchable vulnerability https://github.com/microsoft/azure-pipelines-task-lib/pull/968